### PR TITLE
add the ebs throughput parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,7 @@ resource "aws_elasticsearch_domain" "default" {
     volume_size = var.ebs_volume_size
     volume_type = var.ebs_volume_type
     iops        = var.ebs_iops
+    throughput  = var.ebs_throughput
   }
 
   encrypt_at_rest {

--- a/variables.tf
+++ b/variables.tf
@@ -141,6 +141,12 @@ variable "ebs_iops" {
   description = "The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type"
 }
 
+variable "ebs_throughput" {
+  type        = number
+  default     = null
+  description = "Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type. Valid values are between 125 and 1000."
+}
+
 variable "encrypt_at_rest_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what
* add the ebs throughput parameter to be added to terraform

## why
* Latest AWS provider needs the throughput parameter to be added to terraform
* It seems to be affected by a change in specifications on the AWS side.
https://awsapichanges.info/archive/changes/8875a3-ec2.html


## references
* https://awsapichanges.info/archive/changes/8875a3-ec2.html
* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html#current-memory-optimized



